### PR TITLE
Update 2017-01-30.tex

### DIFF
--- a/lec/2017-01-30.tex
+++ b/lec/2017-01-30.tex
@@ -387,7 +387,7 @@ we want
 \]
 One ``obvious'' consistent norm is the {\em Frobenius norm},
 \[
-  A = \sum_{i,j} a_{ij}^2.
+  \|A\|_F^2 = \sum_{i,j} a_{ij}^2.
 \]
 Even more useful are {\em induced norms} (or {\em operator norms})
 \[


### PR DESCRIPTION
This seems like a quick typo. Also, this may have led to the confusion today when somebody said the Frobenius norm of the identity matrix is n.